### PR TITLE
Fix model parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,9 +75,8 @@ module.exports = function(homebridge) {
 		else {
 			// Split manufacturer and model
 			const modelSplit = (device.model || '').split(':');
-			const m = modelSplit.length === 2 ? modelSplit: [ 'unknown', 'unknown' ];
-			this.model = m[0];
-			this.manufacturer = m[1];
+			this.model = modelSplit[0] || 'unknown';
+			this.manufacturer = modelSplit[1] || 'unknown';
 		}
 
 		// Device log

--- a/index.js
+++ b/index.js
@@ -40,7 +40,14 @@ module.exports = function(homebridge) {
 				{ service: Service.TemperatureSensor, characteristics: [ Characteristic.CurrentTemperature ] },
 				{ service: Service.HumiditySensor, characteristics: [ Characteristic.CurrentRelativeHumidity ] }
 			]
-		}
+		},
+		{
+			model: '1A2D',
+			definitions: [
+				{ service: Service.TemperatureSensor, characteristics: [ Characteristic.CurrentTemperature ] },
+				{ service: Service.HumiditySensor, characteristics: [ Characteristic.CurrentRelativeHumidity ] }
+			]
+		},
 	];
 
 	homebridge.registerPlatform("homebridge-telldus", "Telldus", TelldusPlatform);

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "bluebird": "^3.4.6",
+    "debug": "^2.2.0",
     "telldus-live": "^0.2.1"
   }
 }


### PR DESCRIPTION
See discussion in #1 

* Don't crash if model is missing from getDeviceInfo.
* Fix model parsing when name doesn't contain ':'
* Add debug logging of getDeviceInfo responses enabled by env var (See https://github.com/visionmedia/debug )
